### PR TITLE
feat: API 계층 분리 및 스토어 리팩토링

### DIFF
--- a/frontend/chu/src/api/chu.ts
+++ b/frontend/chu/src/api/chu.ts
@@ -1,0 +1,32 @@
+import apiClient, { type ApiResponse } from "./index";
+import type { Chu, ChuSkin } from "../types/model";
+
+// 사용자의 메인 츄 정보를 가져오는 api
+export const fetchMainChuAPI = async (): Promise<Chu> => {
+  try {
+    const response = await apiClient.get<ApiResponse<Chu>>("/chu/main");
+    if (response.data.success) {
+      return response.data.data;
+    } else {
+      throw new Error(response.data.error?.message || "츄 정보를 가져오는 중 알 수 없는 오류가 발생했습니다.");
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다.";
+    throw new Error(message);
+  }
+};
+
+// 사용자가 보유한 츄 스킨(언어)의 상태 목록을 가져오는 api
+export const fetchAllChuSkinsAPI = async (): Promise<ChuSkin[]> => {
+  try {
+    const response = await apiClient.get<ApiResponse<any[]>>("/chu/list");
+    if (response.data.success) {
+      return response.data.data;
+    } else {
+      throw new Error(response.data.error?.message || "전체 츄 스킨 목록을 불러오는데 실패했습니다.");
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다.";
+    throw new Error(message);
+  }
+};

--- a/frontend/chu/src/api/index.ts
+++ b/frontend/chu/src/api/index.ts
@@ -1,6 +1,16 @@
-// 파일명 바꿀까나 axios로~
-
 import axios from "axios";
+
+// 제네릭을 사용한 공통 API 응답 인터페이스
+export interface ApiResponse<T> {
+  success: boolean;
+  data: T;
+  // 선택적 프로퍼티 필드 (에러 코드와 메시지)
+  error?: {
+    code: string;
+    message: string;
+  };
+  timestamp: string;
+}
 
 const apiClient = axios.create({
   baseURL: "/api", // 백엔드 API 프록시 경로

--- a/frontend/chu/src/api/user.ts
+++ b/frontend/chu/src/api/user.ts
@@ -1,0 +1,30 @@
+import apiClient, { type ApiResponse } from "./index";
+import type { User } from "../types/model";
+
+// 내 정보를 가져오는 api
+export const fetchUserAPI = async (): Promise<User> => {
+  try {
+    const response = await apiClient.get<ApiResponse<User>>("/user/me");
+    if (response.data.success) {
+      return response.data.data;
+    } else {
+      throw new Error(response.data.error?.message || "사용자 정보를 불러오는데 실패했습니다.");
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다.";
+    throw new Error(message);
+  }
+};
+
+// 로그아웃 api
+export const logoutAPI = async (): Promise<void> => {
+  try {
+    const response = await apiClient.post<ApiResponse<Record<string, never>>>("/user/logout");
+    if (!response.data.success) {
+      throw new Error(response.data.error?.message || "로그아웃에 실패했습니다.");
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다.";
+    throw new Error(message);
+  }
+};

--- a/frontend/chu/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/chu/src/pages/Dashboard/Dashboard.tsx
@@ -1,54 +1,56 @@
 import { useEffect } from "react";
-import { Navigate } from "react-router-dom";
-import useUserStore from "../../store/userStore";
 import useChuStore from "../../store/chuStore";
 import styles from "./Dashboard.module.css";
 
 const Dashboard = () => {
-  // 후에 i18n 적용해야함~
-  const { user } = useUserStore();
-  const { chus, isLoading, error, fetchChus } = useChuStore();
+  const { mainChu, chuSkins, isLoading, error, fetchMainChu, fetchAllChuSkins } = useChuStore();
 
   useEffect(() => {
-    fetchChus();
-  }, [fetchChus]);
+    fetchMainChu();
+    fetchAllChuSkins();
+  }, [fetchMainChu, fetchAllChuSkins]);
 
-  if (!user) {
-    return <Navigate to="/" replace />;
+  if (isLoading) {
+    return <p>Loading your Chus...</p>;
   }
 
-  const renderContent = () => {
-    if (isLoading) {
-      return <p>Loading your Chus...</p>;
-    }
-
-    if (error) {
-      return <p>Error: {error}</p>;
-    }
-
-    if (chus.length > 0) {
-      // 메인 츄를 찾거나, 없으면 첫 번째 츄를 보여줍니다.
-      const mainChu = chus.find((chu) => chu.isMain) || chus[0];
-      return (
-        <div className={styles.petSection}>
-          {/* PetCard가 Chu 타입을 받을 수 있도록 수정이 필요할 수 있습니다. */}
-          {/* 우선 chu 객체를 pet prop으로 넘겨봅니다. */}
-        </div>
-      );
-    }
-
-    return (
-      <div className={styles.creatorSection}>
-        <h2 className={styles.subtitle}>Create Your ComitChu</h2>
-        <p className={styles.description}>Choose your perfect coding companion from the characters below!</p>
-      </div>
-    );
-  };
+  if (error) {
+    return <p>Error: {error}</p>;
+  }
 
   return (
     <div className={styles.dashboard}>
-      <h1 className={styles.title}>Dashboard</h1>
-      {renderContent()}
+      <h1 className={styles.title}>My Dashboard</h1>
+
+      <section className={styles.mainChuSection}>
+        <h2>My Main Chu</h2>
+        {mainChu ? (
+          <div>
+            <p>Nickname: {mainChu.nickname}</p>
+            <p>Level: {mainChu.level}</p>
+            <p>Language: {mainChu.lang}</p>
+          </div>
+        ) : (
+          <p>No main chu selected.</p>
+        )}
+      </section>
+
+      <section className={styles.chuSkinsSection}>
+        <h2>My Language Skins</h2>
+        {chuSkins.length > 0 ? (
+          <ul className={styles.skinList}>
+            {chuSkins.map((skin) => (
+              <li key={skin.langId} className={skin.isUnlocked ? styles.unlocked : styles.locked}>
+                Language ID: {skin.langId}
+                {skin.isMain && <span> (Main)</span>}
+                {skin.isUnlocked ? " (Unlocked)" : " (Locked)"}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>No language skins found.</p>
+        )}
+      </section>
     </div>
   );
 };

--- a/frontend/chu/src/store/userStore.ts
+++ b/frontend/chu/src/store/userStore.ts
@@ -1,28 +1,8 @@
 import { create } from "zustand";
-import apiClient from "../api";
-import type { User, Chu } from "../types/model";
-
-// 제네릭을 사용한 공통 API 응답 인터페이스
-interface ApiResponse<T> {
-  success: boolean;
-  data: T;
-  // 선택적 프로퍼티 필드 (에러 코드와 메시지)
-  error?: {
-    code: string;
-    message: string;
-  };
-  timestamp: string;
-}
-
-// fetchUser API가 반환하는 data의 타입
-interface UserData {
-  userName: string;
-  avatarUrl: string;
-}
+import type { User } from "../types/model";
+import { fetchUserAPI, logoutAPI } from "../api/user";
 
 // 각 api를 호출하면서 만들 메서드 이름을 여기에 정리하기
-// 후에 기능 완료 후 필요없는 기능은 날려야댐
-// pet -> chu로 필드명 변경
 interface UserState {
   user: User | null;
   isLoggedIn: boolean;
@@ -41,45 +21,31 @@ const useUserStore = create<UserState>((set) => ({
   fetchUser: async () => {
     set({ isLoading: true, error: null });
     try {
-      const response = await apiClient.get<ApiResponse<UserData>>("/user/me");
-      if (response.data.success) {
-        const { userName, avatarUrl } = response.data.data;
-        const userData: User = {
-          userName,
-          avatarUrl,
-        };
-        set({ user: userData, isLoggedIn: true, isLoading: false });
-      } else {
-        set({
-          user: null,
-          isLoggedIn: false,
-          isLoading: false,
-          error: response.data.error?.message || "사용자 정보를 불러오는데 실패했습니다.",
-        });
-      }
+      const userData = await fetchUserAPI();
+      set({ user: userData, isLoggedIn: true, isLoading: false });
     } catch (error) {
       set({
         user: null,
         isLoggedIn: false,
         isLoading: false,
-        error: "네트워크 오류가 발생했습니다. 다시 시도해주세요.",
+        error: error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다.",
       });
     }
   },
   logout: async () => {
     set({ isLoading: true, error: null });
     try {
-      await apiClient.post<ApiResponse<Record<string, never>>>("/user/logout");
+      await logoutAPI();
       set({ user: null, isLoggedIn: false, isLoading: false });
     } catch (error) {
       // API 에러가 발생하더라도 로그아웃은 처리되어야 합니다.
       // 사용자 경험을 위해 에러 메시지는 상태에 저장합니다.
-      const anyError = error as any;
-      let errorMessage = "로그아웃 중 오류가 발생했습니다.";
-      if (anyError.response && anyError.response.data && anyError.response.data.error) {
-        errorMessage = anyError.response.data.error.message;
-      }
-      set({ user: null, isLoggedIn: false, isLoading: false, error: errorMessage });
+      set({
+        user: null,
+        isLoggedIn: false,
+        isLoading: false,
+        error: error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다.",
+      });
     }
   },
   // setUser는 api를 호출하지 않고 사용자 정보를 불러올 때 쓴다

--- a/frontend/chu/src/types/model.d.ts
+++ b/frontend/chu/src/types/model.d.ts
@@ -9,11 +9,17 @@ export interface User {
 
 // 츄 데이터 모델
 export interface Chu {
-  chuId: number;
-  nikname: string;
+  nickname: string;
   level: number;
   exp: number;
   status: string;
+  lang: string;
+  background: string;
+}
+
+// 츄 스킨 모델
+export interface ChuSkin {
+  langId: number;
   isMain: boolean;
-  lastStateUpdatedAt: string;
+  isUnlocked: boolean;
 }


### PR DESCRIPTION
- **API 계층 분리:**
  - `src/api` 디렉토리를 신설하여 API 통신 관련 로직을 중앙에서 관리하도록 구조를 변경했습니다.
  - `apiClient` 인스턴스와 공통 응답 타입(`ApiResponse`)을 `api/index.ts`에 정의했습니다.
  - `user` 및 `chu` 도메인에 대한 API 호출 함수들을 `api/user.ts`와 `api/chu.ts`에 각각 분리하여 구현했습니다.

- **스토어 리팩토링:**
  - `userStore`와 `chuStore`가 더 이상 `axios`를 직접 호출하지 않고, 새로 만든 API 계층의 함수를 사용하도록 수정했습니다.
  - 이를 통해 스토어는 상태 관리에만 집중할 수 있게 되어 코드의 관심사가 명확해지고 테스트 용이성이 향상되었습니다.
  - `chuStore`는 이제 `mainChu` 상세 정보와 `chuSkins` 목록을 모두 관리합니다.

- **타입 정의 수정:**
  - `types/model.d.ts`에 새로운 API 명세에 맞는 `Chu`와 `ChuSkin` 타입을 정의하고, 불필요한 타입을 제거했습니다.

- **대시보드 UI 업데이트:**
  - `Dashboard.tsx`가 리팩토링된 `chuStore`를 사용하도록 수정했습니다.
  - 이제 메인 츄 정보와 전체 츄 스킨 목록을 API로부터 받아와 화면에 렌더링합니다.