### PR TITLE
feat: X-DEV-USER 헤더 관리 개선

### DIFF
--- a/frontend/chu/src/api/index.ts
+++ b/frontend/chu/src/api/index.ts
@@ -20,10 +20,9 @@ const apiClient = axios.create({
   },
 });
 
-// 개발 환경에서만 X-DEV-USER 헤더 추가
-if (import.meta.env.DEV) {
-  apiClient.defaults.headers.common["X-DEV-USER"] = "1";
-  console.log("짜증");
+// 개발 환경에 조건과 .env파일 보유시에만 개발자 계정 접속 가능
+if (import.meta.env.DEV && import.meta.env.VITE_DEV_USER_ID) {
+  apiClient.defaults.headers.common["X-DEV-USER"] = import.meta.env.VITE_DEV_USER_ID;
 }
 
 export default apiClient;

--- a/frontend/chu/vite.config.ts
+++ b/frontend/chu/vite.config.ts
@@ -1,15 +1,24 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    proxy: {
-      "/api": {
-        target: "https://www.comitchu.shop",
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ""),
+export default defineConfig(({ mode }) => {
+  // 현재 모드(development, production 등)에 해당하는 .env 파일 로드
+  // 세 번째 인자로 ''를 전달하면 모든 환경 변수를 로드합니다.
+  const env = loadEnv(mode, process.cwd(), "");
+
+  return {
+    plugins: [react()],
+    server: {
+      proxy: {
+        "/api": {
+          target: "https://www.comitchu.shop",
+          changeOrigin: true,
+          headers: {
+            // 로드된 환경 변수 사용
+            "X-DEV-USER": env.VITE_DEV_USER_ID,
+          },
+        },
       },
     },
-  },
+  };
 });


### PR DESCRIPTION
- 프론트엔드에서 X-DEV-USER 헤더 처리를 리팩토링하여 보안 및 유지보수성을 향상했습니다.

- src/api/index.ts 파일을 업데이트하여, 개발 환경 변수(import.meta.env.VITE_DEV_USER_ID)가 존재할 경우에만 X-DEV-USER 헤더를 설정하도록 개선했습니다.

- vite.config.ts 파일에 loadEnv를 적용하여 환경 변수를 올바르게 로드하고, Vite 프록시가 VITE_DEV_USER_ID로부터 X-DEV-USER 헤더를 동적으로 설정하도록 수정했습니다.

vite.config.ts 파일에서 X-DEV-USER의 하드코딩된 폴백 값을 제거하여, 환경 변수 설정을 명확하게 강제했습니다.