### PR TITLE
feat: 대시보드에 사용자 츄 SVG 표시 기능 추가

### DIFF
--- a/frontend/chu/src/api/chu.ts
+++ b/frontend/chu/src/api/chu.ts
@@ -30,3 +30,14 @@ export const fetchAllChuSkinsAPI = async (): Promise<ChuSkin[]> => {
     throw new Error(message);
   }
 };
+
+// githubUsername을 기반으로 츄 svg를 가져오는 api
+export const fetchChuSvgAPI = async (githubUsername: string): Promise<string> => {
+  try {
+    const response = await apiClient.get<string>(`/chu/${githubUsername}`);
+    return response.data;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다.";
+    throw new Error(message);
+  }
+};

--- a/frontend/chu/src/pages/Dashboard/Dashboard.module.css
+++ b/frontend/chu/src/pages/Dashboard/Dashboard.module.css
@@ -1,53 +1,59 @@
 .dashboard {
-  max-width: 1000px;
-  margin: 0 auto;
-  padding: 20px 0;
+  padding: 2rem;
 }
 
 .title {
-  font-size: 36px;
-  font-weight: 700;
-  color: #2c3e50;
-  margin-bottom: 32px;
+  font-size: 2rem;
+  margin-bottom: 1.5rem;
   text-align: center;
 }
 
-.petSection {
+.contentWrapper {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 2rem;
+}
+
+.svgSection {
+  flex: 2;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
   display: flex;
   justify-content: center;
-  padding: 40px 0;
+  align-items: center;
 }
 
-.creatorSection {
-  text-align: center;
+.svgImage {
+  width: 300px;
+  height: 200px;
 }
 
-.subtitle {
-  font-size: 28px;
-  font-weight: 600;
-  color: #4a90e2;
-  margin-bottom: 16px;
+.mainChuSection {
+  flex: 1;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
 }
 
-.description {
-  font-size: 18px;
-  color: #666;
-  margin-bottom: 40px;
-  max-width: 600px;
-  margin-left: auto;
-  margin-right: auto;
+.mainChuSection h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 0.5rem;
 }
 
-@media (max-width: 768px) {
-  .title {
-    font-size: 28px;
-  }
+.loading,
+.error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-size: 1.2rem;
+}
 
-  .subtitle {
-    font-size: 24px;
-  }
-
-  .description {
-    font-size: 16px;
-  }
+.error {
+  color: red;
 }


### PR DESCRIPTION
- githubUsername을 기반으로 츄의 SVG 데이터를 가져오는 fetchChuSvgAPI를 구현했습니다.
- 대시보드 페이지의 레이아웃을 개편하여, API로 받아온 사용자의 츄 SVG 이미지를 표시하는 섹션을 추가했습니다.
- dangerouslySetInnerHTML을 이용해 동적으로 SVG를 렌더링하고, 관련 로딩 및 오류 상태를 처리합니다.