### PR TITLE
Be/feat/chu 53 레벨업 스케줄러 구현

### DIFF
--- a/backend/chu/src/main/java/com/commi/chu/domain/chu/entity/Chu.java
+++ b/backend/chu/src/main/java/com/commi/chu/domain/chu/entity/Chu.java
@@ -50,18 +50,20 @@ public class Chu extends BaseEntity {
 
     public void updateStatus(ChuStatus newStatus) {
         this.status = newStatus;
-        this.lastStatusUpdatedAt = LocalDateTime.now();
     }
 
 
     public void updateLang(String lang) {
         this.lang = lang;
-        this.lastStatusUpdatedAt = LocalDateTime.now();
     }
 
 
     public void updateBackground(String background) {
         this.background = background;
-        this.lastStatusUpdatedAt = LocalDateTime.now();
+    }
+
+    public void levelUp(int level, int exp) {
+        this.level = level;
+        this.exp = exp;
     }
 }

--- a/backend/chu/src/main/java/com/commi/chu/domain/chu/entity/Chu.java
+++ b/backend/chu/src/main/java/com/commi/chu/domain/chu/entity/Chu.java
@@ -1,5 +1,6 @@
 package com.commi.chu.domain.chu.entity;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.LastModifiedDate;
@@ -48,6 +49,9 @@ public class Chu extends BaseEntity {
     @LastModifiedDate
     private LocalDateTime lastStatusUpdatedAt;
 
+    @Column(name = "last_leveled_date_kst")
+    private LocalDate lastLeveledDateKst;
+
     public void updateStatus(ChuStatus newStatus) {
         this.status = newStatus;
     }
@@ -65,5 +69,9 @@ public class Chu extends BaseEntity {
     public void levelUp(int level, int exp) {
         this.level = level;
         this.exp = exp;
+    }
+
+    public void markLeveledToday(LocalDate kstDate) {
+        this.lastLeveledDateKst = kstDate;
     }
 }

--- a/backend/chu/src/main/java/com/commi/chu/domain/chu/scheduler/LevelUpScheduler.java
+++ b/backend/chu/src/main/java/com/commi/chu/domain/chu/scheduler/LevelUpScheduler.java
@@ -1,4 +1,20 @@
 package com.commi.chu.domain.chu.scheduler;
 
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.commi.chu.domain.chu.service.LevelUpService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
 public class LevelUpScheduler {
+
+	private final LevelUpService levelUpService;
+
+	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+	public void levelUp() {
+
+	}
 }

--- a/backend/chu/src/main/java/com/commi/chu/domain/chu/scheduler/LevelUpScheduler.java
+++ b/backend/chu/src/main/java/com/commi/chu/domain/chu/scheduler/LevelUpScheduler.java
@@ -31,7 +31,7 @@ public class LevelUpScheduler {
 				log.info("levelUp 로직 완료 : user={}", user.getGithubUsername());
 			}
 			catch(Exception e){
-				log.error("levelUp 과정에서 에러 발생 : user={}", user.getGithubUsername());
+				log.error("levelUp 과정에서 에러 발생 : user={}", e.getMessage());
 			}
 
 		}

--- a/backend/chu/src/main/java/com/commi/chu/domain/chu/scheduler/LevelUpScheduler.java
+++ b/backend/chu/src/main/java/com/commi/chu/domain/chu/scheduler/LevelUpScheduler.java
@@ -1,20 +1,39 @@
 package com.commi.chu.domain.chu.scheduler;
 
+import java.util.List;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.commi.chu.domain.chu.service.LevelUpService;
+import com.commi.chu.domain.user.entity.User;
+import com.commi.chu.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class LevelUpScheduler {
 
 	private final LevelUpService levelUpService;
+	private final UserRepository userRepository;
 
-	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
-	public void levelUp() {
+	@Scheduled(cron = "0 5 0 * * *", zone = "Asia/Seoul")
+	public void levelUpAllUsers() {
 
+		List<User> users = userRepository.findAll();
+
+		for (User user : users) {
+			try{
+				levelUpService.levelUp(user.getId());
+				log.info("levelUp 로직 완료 : user={}", user.getGithubUsername());
+			}
+			catch(Exception e){
+				log.error("levelUp 과정에서 에러 발생 : user={}", user.getGithubUsername());
+			}
+
+		}
 	}
 }

--- a/backend/chu/src/main/java/com/commi/chu/domain/chu/scheduler/LevelUpScheduler.java
+++ b/backend/chu/src/main/java/com/commi/chu/domain/chu/scheduler/LevelUpScheduler.java
@@ -1,0 +1,4 @@
+package com.commi.chu.domain.chu.scheduler;
+
+public class LevelUpScheduler {
+}

--- a/backend/chu/src/main/java/com/commi/chu/domain/chu/service/ChuService.java
+++ b/backend/chu/src/main/java/com/commi/chu/domain/chu/service/ChuService.java
@@ -168,7 +168,7 @@ public class ChuService {
      * 배경화면을 바꾸는 비즈니스 로직입니다.
      *
      * @param userId 요천한 사용자 Id
-     * @param backgroundName 변경할 배경화면 이름
+     * @param backgroundRequestDto 변경할 배경화면 이름
      * @return 배경화면 변경에 성공했는지 응답
      */
     @Transactional

--- a/backend/chu/src/main/java/com/commi/chu/domain/chu/service/LevelUpService.java
+++ b/backend/chu/src/main/java/com/commi/chu/domain/chu/service/LevelUpService.java
@@ -22,7 +22,12 @@ public class LevelUpService {
 	private final UserRepository userRepository;
 	private final ChuRepository chuRepository;
 
-	private static final int A = 50;
+	private static final int MAX_LEVEL = 100;
+
+
+	private static final long A = 50L;
+
+	//레벨업 기준
 	private static final int W_COMMIT = 2;
 	private static final int W_PR = 8;
 	private static final int W_ISSUE = 5;
@@ -39,25 +44,32 @@ public class LevelUpService {
 		ActivitySnapshot latest = activitySnapshotRepository.findByUser_Id(userId)
 			.orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND, "userId",userId));
 
-		int gainedExp =
-			latest.getCommitCount() * W_COMMIT
-				+ latest.getPrCount()     * W_PR
-				+ latest.getIssueCount()  * W_ISSUE
-				+ latest.getReviewCount() * W_REVIEW;
+		long gainedExp =
+			(long)latest.getCommitCount() * W_COMMIT
+				+ (long)latest.getPrCount()     * W_PR
+				+ (long)latest.getIssueCount()  * W_ISSUE
+				+ (long)latest.getReviewCount() * W_REVIEW;
 
 		int level = chu.getLevel();
-		int exp = chu.getExp()+ gainedExp;
+		long exp = chu.getExp()+ gainedExp;
 
-		while(exp >= requiredExp(level+1)){
-			exp -= requiredExp(level+1);
+		//100레벨이 최대
+		while (level < MAX_LEVEL && exp >= requiredExp(level + 1)) {
+			exp -= requiredExp(level + 1);
 			level++;
 		}
 
-		chu.levelUp(level,exp);
+		//만렙이면 경험치는 0으로 고정
+		if (level >= MAX_LEVEL) {
+			level = MAX_LEVEL;
+			exp   = 0L;
+		}
+
+		chu.levelUp(level, (int) exp);
 	}
 
-	private int requiredExp(int n) {
+	private long requiredExp(int n) {
 		// ExpRequired(n) = a * n^2
-		return A * n * n;
+		return A * (long) n * (long) n;
 	}
 }

--- a/backend/chu/src/main/java/com/commi/chu/domain/chu/service/LevelUpService.java
+++ b/backend/chu/src/main/java/com/commi/chu/domain/chu/service/LevelUpService.java
@@ -1,5 +1,10 @@
 package com.commi.chu.domain.chu.service;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,8 +27,10 @@ public class LevelUpService {
 	private final UserRepository userRepository;
 	private final ChuRepository chuRepository;
 
-	private static final int MAX_LEVEL = 100;
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+	private static final ZoneOffset UTC = ZoneOffset.UTC;
 
+	private static final int MAX_LEVEL = 100;
 
 	private static final long A = 50L;
 
@@ -41,21 +48,47 @@ public class LevelUpService {
 		Chu chu = chuRepository.findByUser(user)
 			.orElseThrow(()-> new CustomException(ErrorCode.CHU_NOT_FOUND));
 
-		ActivitySnapshot latest = activitySnapshotRepository.findByUser_Id(userId)
-			.orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND, "userId",userId));
+		// KST 기준 어제 날짜
+		LocalDate target = LocalDate.now(KST).minusDays(1);
+
+		// 이미 어제 처리 했으면 스킵
+		if (target.equals(chu.getLastLeveledDateKst())) {
+			return;
+		}
+
+		// 어제 KST 00:00:00 ~ 23:59:59 범위를 UTC로 변환
+		Instant startUtc = target.atStartOfDay(KST)
+			.withZoneSameInstant(UTC)
+			.toInstant();
+
+		Instant endUtc = target.plusDays(1).atStartOfDay(KST)
+			.minusNanos(1)
+			.withZoneSameInstant(UTC)
+			.toInstant();
+
+		//어제 업데이트 된 github 통계 데이터가 있는지 확인 없으면 Null
+		ActivitySnapshot snapshot = activitySnapshotRepository.findFirstByUserIdAndCalculatedAtBetweenOrderByCalculatedAtDesc(userId, startUtc, endUtc)
+			.orElse(null);
+
+		if (snapshot == null) {
+			// 스냅샷 지연/미생성 시 스케줄 실패 방지: 예외 대신 스킵
+			return;
+		}
 
 		long gainedExp =
-			(long)latest.getCommitCount() * W_COMMIT
-				+ (long)latest.getPrCount()     * W_PR
-				+ (long)latest.getIssueCount()  * W_ISSUE
-				+ (long)latest.getReviewCount() * W_REVIEW;
+			(long)snapshot.getCommitCount() * W_COMMIT
+				+ (long)snapshot.getPrCount()     * W_PR
+				+ (long)snapshot.getIssueCount()  * W_ISSUE
+				+ (long)snapshot.getReviewCount() * W_REVIEW;
 
 		int level = chu.getLevel();
 		long exp = chu.getExp()+ gainedExp;
 
 		//100레벨이 최대
-		while (level < MAX_LEVEL && exp >= requiredExp(level + 1)) {
-			exp -= requiredExp(level + 1);
+		while (level < MAX_LEVEL) {
+			long need = requiredExp(level + 1);
+			if (exp < need) break;
+			exp -= need;
 			level++;
 		}
 
@@ -66,6 +99,9 @@ public class LevelUpService {
 		}
 
 		chu.levelUp(level, (int) exp);
+
+		//어제 날짜 데이터로 레벨을 계산하기 때문에 어제 날짜로 저장 (다음날 중복 방지)
+		chu.markLeveledToday(target);
 	}
 
 	private long requiredExp(int n) {

--- a/backend/chu/src/main/java/com/commi/chu/domain/chu/service/LevelUpService.java
+++ b/backend/chu/src/main/java/com/commi/chu/domain/chu/service/LevelUpService.java
@@ -1,4 +1,63 @@
 package com.commi.chu.domain.chu.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.commi.chu.domain.chu.entity.Chu;
+import com.commi.chu.domain.chu.repository.ChuRepository;
+import com.commi.chu.domain.github.entity.ActivitySnapshot;
+import com.commi.chu.domain.github.repository.ActivitySnapshotRepository;
+import com.commi.chu.domain.user.entity.User;
+import com.commi.chu.domain.user.repository.UserRepository;
+import com.commi.chu.global.exception.CustomException;
+import com.commi.chu.global.exception.code.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
 public class LevelUpService {
+
+	private final ActivitySnapshotRepository activitySnapshotRepository;
+	private final UserRepository userRepository;
+	private final ChuRepository chuRepository;
+
+	private static final int A = 50;
+	private static final int W_COMMIT = 2;
+	private static final int W_PR = 8;
+	private static final int W_ISSUE = 5;
+	private static final int W_REVIEW = 6;
+
+	@Transactional
+	public void levelUp(Integer userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_FOUND,"userId",userId));
+
+		Chu chu = chuRepository.findByUser(user)
+			.orElseThrow(()-> new CustomException(ErrorCode.CHU_NOT_FOUND));
+
+		ActivitySnapshot latest = activitySnapshotRepository.findByUser_Id(userId)
+			.orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND, "userId",userId));
+
+		int gainedExp =
+			latest.getCommitCount() * W_COMMIT
+				+ latest.getPrCount()     * W_PR
+				+ latest.getIssueCount()  * W_ISSUE
+				+ latest.getReviewCount() * W_REVIEW;
+
+		int level = chu.getLevel();
+		int exp = chu.getExp()+ gainedExp;
+
+		while(exp >= requiredExp(level+1)){
+			exp -= requiredExp(level+1);
+			level++;
+		}
+
+		chu.levelUp(level,exp);
+	}
+
+	private int requiredExp(int n) {
+		// ExpRequired(n) = a * n^2
+		return A * n * n;
+	}
 }

--- a/backend/chu/src/main/java/com/commi/chu/domain/chu/service/LevelUpService.java
+++ b/backend/chu/src/main/java/com/commi/chu/domain/chu/service/LevelUpService.java
@@ -1,0 +1,4 @@
+package com.commi.chu.domain.chu.service;
+
+public class LevelUpService {
+}

--- a/backend/chu/src/main/java/com/commi/chu/domain/github/entity/ActivitySnapshot.java
+++ b/backend/chu/src/main/java/com/commi/chu/domain/github/entity/ActivitySnapshot.java
@@ -46,7 +46,6 @@ public class ActivitySnapshot extends BaseEntity {
         this.prCount = prCount;
         this.issueCount = issueCount;
         this.reviewCount = reviewCount;
-        this.calculatedAt = LocalDateTime.now();
         return this;
     }
 

--- a/backend/chu/src/main/java/com/commi/chu/domain/github/repository/ActivitySnapshotRepository.java
+++ b/backend/chu/src/main/java/com/commi/chu/domain/github/repository/ActivitySnapshotRepository.java
@@ -3,10 +3,13 @@ package com.commi.chu.domain.github.repository;
 import com.commi.chu.domain.github.entity.ActivitySnapshot;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.Instant;
 import java.util.Optional;
 
 public interface ActivitySnapshotRepository extends JpaRepository<ActivitySnapshot, Integer> {
 
     Optional<ActivitySnapshot> findByUser_Id(Integer userId);
+
+    Optional<ActivitySnapshot> findFirstByUserIdAndCalculatedAtBetweenOrderByCalculatedAtDesc(Integer userId, Instant start, Instant end);
 
 }

--- a/backend/chu/src/main/java/com/commi/chu/domain/github/repository/ActivitySnapshotRepository.java
+++ b/backend/chu/src/main/java/com/commi/chu/domain/github/repository/ActivitySnapshotRepository.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 
 public interface ActivitySnapshotRepository extends JpaRepository<ActivitySnapshot, Integer> {
 
-    Optional<ActivitySnapshot> findActivitySnapshotByUserId(Integer userId);
+    Optional<ActivitySnapshot> findByUser_Id(Integer userId);
 
 }

--- a/backend/chu/src/main/java/com/commi/chu/domain/github/repository/ActivitySnapshotRepository.java
+++ b/backend/chu/src/main/java/com/commi/chu/domain/github/repository/ActivitySnapshotRepository.java
@@ -4,12 +4,14 @@ import com.commi.chu.domain.github.entity.ActivitySnapshot;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface ActivitySnapshotRepository extends JpaRepository<ActivitySnapshot, Integer> {
 
     Optional<ActivitySnapshot> findByUser_Id(Integer userId);
 
-    Optional<ActivitySnapshot> findFirstByUserIdAndCalculatedAtBetweenOrderByCalculatedAtDesc(Integer userId, Instant start, Instant end);
+    Optional<ActivitySnapshot> findFirstByUserIdAndCalculatedAtGreaterThanEqualAndCalculatedAtLessThanOrderByCalculatedAtDesc(Integer user_id,
+        LocalDateTime calculatedAt, LocalDateTime calculatedAt2);
 
 }

--- a/backend/chu/src/main/java/com/commi/chu/domain/github/service/GithubStatService.java
+++ b/backend/chu/src/main/java/com/commi/chu/domain/github/service/GithubStatService.java
@@ -2,7 +2,6 @@ package com.commi.chu.domain.github.service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -119,7 +118,7 @@ public class GithubStatService {
 
         logRepository.save(snapshotLog);
 
-        ActivitySnapshot githubStat = activitySnapshotRepository.findActivitySnapshotByUserId(user.getId())
+        ActivitySnapshot githubStat = activitySnapshotRepository.findByUser_Id(user.getId())
                 .map(existingStat ->
                         //기존의 github 통계를 업데이트한다.
                         existingStat.updateSnapshot(commitCount, prCount, issueCount, reviewCount)


### PR DESCRIPTION
- 레벨업 로직 구현
- 레벨업 스케줄러 구현 ( 통계 계산 스케줄러와 약 5분정도 차이나게 설정)
- DB가 UTC 저장이므로 어제 KST 00:00~23:59:59 범위를 UTC로 변환해 ActivitySnapShot 조회 (통계 계산 스케줄러가 지연돼서 그 전날 통계 데이터로 계산하는 상황 방지)
- 이미 어제 처리한 경우 레벨업 스킵하도록 lastLeveledDateKst 가드 추가 (스케줄러가 두번 돌아가는 상황 방지)
- 스냅샷 미존재 시 예외 대신 스킵 처리