### PR TITLE
feat(frontend): 랜딩 페이지 및 UI/UX 전면 개편

### DIFF
--- a/frontend/chu/package.json
+++ b/frontend/chu/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.11.0",
+    "gsap": "^3.13.0",
     "i18next": "^25.3.2",
     "i18next-browser-languagedetector": "^8.2.0",
     "motion": "^12.23.12",

--- a/frontend/chu/src/components/BackgroundSelector/BackgroundSelector.module.css
+++ b/frontend/chu/src/components/BackgroundSelector/BackgroundSelector.module.css
@@ -3,7 +3,6 @@
   border: 1px solid #ccc;
   border-radius: 8px;
   margin-top: 1rem;
-  pointer-events: auto;
 }
 
 .gridContainer {

--- a/frontend/chu/src/components/ChuSkinSelector/ChuSkinSelector.module.css
+++ b/frontend/chu/src/components/ChuSkinSelector/ChuSkinSelector.module.css
@@ -3,7 +3,6 @@
   border: 1px solid #ccc;
   border-radius: 8px;
   margin-top: 1rem;
-  pointer-events: auto;
 }
 
 .gridContainer {

--- a/frontend/chu/src/components/Header/Header.module.css
+++ b/frontend/chu/src/components/Header/Header.module.css
@@ -1,12 +1,11 @@
 .header {
-  background-color: #02040a;
+  background-color: transparent;
   border-bottom: 1px solid #3d444d;
   position: relative;
   justify-content: center;
   top: 0;
   height: 80px;
   z-index: 100;
-  pointer-events: none;
 }
 
 .container {
@@ -25,14 +24,33 @@
   font-weight: 700;
   text-decoration: none;
   color: #f0f6fc;
-  pointer-events: auto;
 }
 
 .nav {
   display: flex;
   align-items: center;
-  gap: 12px;
+  width: 100%; /* nav가 container 전체 너비를 차지하도록 설정 */
 }
+
+/* === 새로 추가할 스타일 === */
+.left,
+.center,
+.right {
+  flex: 1; /* 세 구역이 동일한 너비를 갖도록 설정 */
+}
+
+.center {
+  display: flex;
+  justify-content: center; /* 중앙 정렬 */
+}
+
+.right {
+  display: flex;
+  justify-content: flex-end; /* 우측 정렬 */
+  align-items: center;
+  gap: 12px; /* 오른쪽 구역 아이템들 사이의 간격 */
+}
+/* === 여기까지 추가 === */
 
 .navLink {
   text-decoration: none;
@@ -42,7 +60,6 @@
   border-radius: 24px;
   transition: all 0.2s ease;
   color: #f0f6fc;
-  pointer-events: auto;
 }
 
 .navLink:hover {
@@ -82,5 +99,4 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  pointer-events: auto;
 }

--- a/frontend/chu/src/components/Header/Header.tsx
+++ b/frontend/chu/src/components/Header/Header.tsx
@@ -3,10 +3,11 @@ import useUserStore from "../../store/userStore";
 import LanguageToggle from "../LanguageToggle/LanguageToggle";
 import styles from "./Header.module.css";
 import { LogoutIcon } from "./LogoutIcon";
+import PillNav from "../ReactBits/PillNav";
+import logo from "../../../public/favicon.ico";
 
 const Header = () => {
   const { user, logout } = useUserStore();
-  const location = useLocation();
   const handleLogout = () => {
     logout();
   };
@@ -14,30 +15,35 @@ const Header = () => {
   return (
     <header className={styles.header}>
       <div className={styles.container}>
-        <Link to="/" className={styles.logo}>
-          ComitChu
-        </Link>
-
         <nav className={styles.nav}>
-          {user && (
-            <>
-              <Link
-                to="/dashboard"
-                className={`${styles.navLink} ${location.pathname === "/dashboard" ? styles.active : ""}`}
-              >
-                Dashboard
-              </Link>
-              <Link
-                to="/custom"
-                className={`${styles.navLink} ${location.pathname === "/custom" ? styles.active : ""}`}
-              >
-                Custom
-              </Link>
-            </>
-          )}
-          <LanguageToggle />
-          {user && (
-            <>
+          {/* 왼쪽 구역 (공간 확보용) */}
+          <div className={styles.left}></div>
+
+          {/* 중앙 구역 (PillNav) */}
+          <div className={styles.center}>
+            {user && (
+              <PillNav
+                logo={logo}
+                logoAlt="ComitChu Logo"
+                items={[
+                  { label: "Home", href: "/" },
+                  { label: "Dashboard", href: "/dashboard" },
+                  { label: "Custom", href: "/custom" },
+                ]}
+                className="custom-nav"
+                ease="power2.easeOut"
+                baseColor="#eeeeee"
+                pillColor="#000000"
+                hoveredPillTextColor="#000000"
+                pillTextColor="#eeeeee"
+              />
+            )}
+          </div>
+
+          {/* 오른쪽 구역 (언어 토글, 유저 정보) */}
+          <div className={styles.right}>
+            <LanguageToggle />
+            {user && (
               <div className={styles.userInfo}>
                 <svg viewBox="0 0 22 22" height="32px" width="32px">
                   <path
@@ -50,8 +56,8 @@ const Header = () => {
                   <LogoutIcon />
                 </button>
               </div>
-            </>
-          )}
+            )}
+          </div>
         </nav>
       </div>
     </header>

--- a/frontend/chu/src/components/LanguageToggle/LanguageToggle.module.css
+++ b/frontend/chu/src/components/LanguageToggle/LanguageToggle.module.css
@@ -5,7 +5,6 @@
   justify-content: center;
   gap: 0.5rem;
   padding: 8px 16px;
-  pointer-events: auto;
 }
 
 .toggleBtn {

--- a/frontend/chu/src/components/ReactBits/HoloCard.module.css
+++ b/frontend/chu/src/components/ReactBits/HoloCard.module.css
@@ -1,0 +1,20 @@
+.container {
+  position: relative;
+  transition: all 0.1s;
+  transform-style: preserve-3d;
+  will-change: transform;
+  pointer-events: auto;
+  width: 100%; /* 너비를 부모 컨테이너에 맞게 수정 */
+  max-width: 400px; /* 카드가 너무 커지는 것을 방지 */
+  aspect-ratio: 2 / 1; /* 높이가 너비에 맞춰 비율대로 자동 설정되도록 수정 */
+}
+
+.card {
+  background-size: cover;
+  background-position: center;
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  /* 선택: 보기 좋게 약간의 그림자 */
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
+}

--- a/frontend/chu/src/components/ReactBits/HoloCard.tsx
+++ b/frontend/chu/src/components/ReactBits/HoloCard.tsx
@@ -1,0 +1,66 @@
+import React, { useRef, useCallback } from "react";
+import styles from "./HoloCard.module.css";
+
+type HoloCardProps = {
+  imageSrc: string; // 예: "/images/pika.webp"
+  perspective?: number; // 기본 350(px)
+  className?: string; // 외부에서 추가 스타일이 필요할 때
+  alt?: string; // 접근성용 설명
+};
+
+const HoloCard: React.FC<HoloCardProps> = ({ imageSrc, perspective = 350, className, alt = "" }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const cardRef = useRef<HTMLDivElement | null>(null);
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!containerRef.current || !overlayRef.current) return;
+
+      // offsetX/Y는 React 합성 이벤트에 직접 없음 -> 현재 타겟 기준 좌표 계산
+      const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
+      const x = e.clientX - rect.left; // 0 ~ width
+      const y = e.clientY - rect.top; // 0 ~ height
+
+      // 원본 수식 유지
+      const rotateY = (-1 / 5) * x + 20;
+      const rotateX = (4 / 30) * y - 20;
+
+      overlayRef.current.style.backgroundPosition = `${x / 5 + y / 5}%`;
+      overlayRef.current.style.filter = `opacity(${x / 200}) brightness(1.2)`;
+
+      containerRef.current.style.transform = `perspective(${perspective}px) rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
+    },
+    [perspective]
+  );
+
+  const handleMouseLeave = useCallback(() => {
+    if (!containerRef.current || !overlayRef.current) return;
+
+    overlayRef.current.style.filter = "opacity(0)";
+    containerRef.current.style.transform = `perspective(${perspective}px) rotateY(0deg) rotateX(0deg)`;
+  }, [perspective]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`${styles.container} ${className ?? ""}`}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+      aria-label={alt}
+      role="img"
+    >
+      <div ref={overlayRef} />
+      <div
+        ref={cardRef}
+        className={styles.card}
+        style={{
+          backgroundImage: `url(${imageSrc})`,
+        }}
+        aria-hidden
+      />
+    </div>
+  );
+};
+
+export default HoloCard;

--- a/frontend/chu/src/components/ReactBits/PillNav.css
+++ b/frontend/chu/src/components/ReactBits/PillNav.css
@@ -1,0 +1,237 @@
+.pill-nav-container {
+  position: absolute;
+  top: 1em;
+  z-index: 99;
+}
+
+@media (max-width: 768px) {
+  .pill-nav-container {
+    width: 100%;
+    left: 0;
+  }
+}
+
+.pill-nav {
+  --nav-h: 42px;
+  --logo: 36px;
+  --pill-pad-x: 18px;
+  --pill-gap: 3px;
+  width: max-content;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+}
+
+@media (max-width: 768px) {
+  .pill-nav {
+    width: 100%;
+    justify-content: space-between;
+    padding: 0 1rem;
+    background: transparent;
+  }
+}
+
+.pill-nav-items {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: var(--nav-h);
+  background: var(--base, #000);
+  border-radius: 12px;
+}
+
+.pill-logo {
+  width: var(--nav-h);
+  height: var(--nav-h);
+  border-radius: 12px;
+  background: var(--base, #000);
+  padding: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.pill-logo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.pill-list {
+  list-style: none;
+  display: flex;
+  align-items: stretch;
+  gap: var(--pill-gap);
+  margin: 0;
+  padding: 3px;
+  height: 100%;
+}
+
+.pill-list > li {
+  display: flex;
+  height: 100%;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 0 var(--pill-pad-x);
+  background: var(--pill-bg, #fff);
+  color: var(--pill-text, var(--base, #000));
+  text-decoration: none;
+  border-radius: 12px;
+  box-sizing: border-box;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.2px;
+  white-space: nowrap;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+}
+
+.pill .hover-circle {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  border-radius: 12px;
+  background: var(--base, #000);
+  z-index: 1;
+  display: block;
+  pointer-events: none;
+  will-change: transform;
+}
+
+.pill .label-stack {
+  position: relative;
+  display: inline-block;
+  line-height: 1;
+  z-index: 2;
+}
+
+.pill .pill-label {
+  position: relative;
+  z-index: 2;
+  display: inline-block;
+  line-height: 1;
+  will-change: transform;
+}
+
+.pill .pill-label-hover {
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--hover-text, #fff);
+  z-index: 3;
+  display: inline-block;
+  will-change: transform, opacity;
+}
+
+.pill.is-active::after {
+  content: "";
+  position: absolute;
+  bottom: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 12px;
+  height: 12px;
+  background: var(--base, #000);
+  border-radius: 12px;
+  z-index: 4;
+}
+
+.desktop-only {
+  display: block;
+}
+
+.mobile-only {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .desktop-only {
+    display: none;
+  }
+
+  .mobile-only {
+    display: block;
+  }
+}
+
+.mobile-menu-button {
+  width: var(--nav-h);
+  height: var(--nav-h);
+  border-radius: 12px;
+  background: var(--base, #000);
+  border: none;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  cursor: pointer;
+  padding: 0;
+  position: relative;
+}
+
+@media (max-width: 768px) {
+  .mobile-menu-button {
+    display: flex;
+  }
+}
+
+.hamburger-line {
+  width: 16px;
+  height: 2px;
+  background: var(--pill-bg, #fff);
+  border-radius: 1px;
+  transition: all 0.01s ease;
+  transform-origin: center;
+}
+
+.mobile-menu-popover {
+  position: absolute;
+  top: 3em;
+  left: 1rem;
+  right: 1rem;
+  background: var(--base, #f0f0f0);
+  border-radius: 27px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+  z-index: 998;
+  opacity: 0;
+  transform-origin: top center;
+  visibility: hidden;
+}
+
+.mobile-menu-list {
+  list-style: none;
+  margin: 0;
+  padding: 3px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.mobile-menu-popover .mobile-menu-link {
+  display: block;
+  padding: 12px 16px;
+  color: var(--pill-text, #fff);
+  background-color: var(--pill-bg, #fff);
+  text-decoration: none;
+  font-size: 16px;
+  font-weight: 500;
+  border-radius: 50px;
+  transition: all 0.2s ease;
+}
+
+.mobile-menu-popover .mobile-menu-link:hover {
+  cursor: pointer;
+  background-color: var(--base);
+  color: var(--hover-text, #fff);
+}

--- a/frontend/chu/src/components/ReactBits/PillNav.tsx
+++ b/frontend/chu/src/components/ReactBits/PillNav.tsx
@@ -1,0 +1,372 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { gsap } from "gsap";
+import "./PillNav.css";
+
+export type PillNavItem = {
+  label: string;
+  href: string;
+  ariaLabel?: string;
+};
+
+export interface PillNavProps {
+  logo: string;
+  logoAlt?: string;
+  items: PillNavItem[];
+  activeHref?: string;
+  className?: string;
+  ease?: string;
+  baseColor?: string;
+  pillColor?: string;
+  hoveredPillTextColor?: string;
+  pillTextColor?: string;
+  onMobileMenuClick?: () => void;
+  initialLoadAnimation?: boolean;
+}
+
+const PillNav: React.FC<PillNavProps> = ({
+  logo,
+  logoAlt = "Logo",
+  items,
+  activeHref,
+  className = "",
+  ease = "power3.easeOut",
+  baseColor = "#fff",
+  pillColor = "#060010",
+  hoveredPillTextColor = "#060010",
+  pillTextColor,
+  onMobileMenuClick,
+  initialLoadAnimation = true,
+}) => {
+  const resolvedPillTextColor = pillTextColor ?? baseColor;
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const circleRefs = useRef<Array<HTMLSpanElement | null>>([]);
+  const tlRefs = useRef<Array<gsap.core.Timeline | null>>([]);
+  const activeTweenRefs = useRef<Array<gsap.core.Tween | null>>([]);
+  const logoImgRef = useRef<HTMLImageElement | null>(null);
+  const logoTweenRef = useRef<gsap.core.Tween | null>(null);
+  const hamburgerRef = useRef<HTMLButtonElement | null>(null);
+  const mobileMenuRef = useRef<HTMLDivElement | null>(null);
+  const navItemsRef = useRef<HTMLDivElement | null>(null);
+  const logoRef = useRef<HTMLAnchorElement | HTMLElement | null>(null);
+
+  useEffect(() => {
+    const layout = () => {
+      circleRefs.current.forEach((circle) => {
+        if (!circle?.parentElement) return;
+
+        const pill = circle.parentElement as HTMLElement;
+        const rect = pill.getBoundingClientRect();
+        const { width: w, height: h } = rect;
+        const R = ((w * w) / 4 + h * h) / (2 * h);
+        const D = Math.ceil(2 * R) + 2;
+        const delta = Math.ceil(R - Math.sqrt(Math.max(0, R * R - (w * w) / 4))) + 1;
+        const originY = D - delta;
+
+        circle.style.width = `${D}px`;
+        circle.style.height = `${D}px`;
+        circle.style.bottom = `-${delta}px`;
+
+        gsap.set(circle, {
+          xPercent: -50,
+          scale: 0,
+          transformOrigin: `50% ${originY}px`,
+        });
+
+        const label = pill.querySelector<HTMLElement>(".pill-label");
+        const white = pill.querySelector<HTMLElement>(".pill-label-hover");
+
+        if (label) gsap.set(label, { y: 0 });
+        if (white) gsap.set(white, { y: h + 12, opacity: 0 });
+
+        const index = circleRefs.current.indexOf(circle);
+        if (index === -1) return;
+
+        tlRefs.current[index]?.kill();
+        const tl = gsap.timeline({ paused: true });
+
+        tl.to(circle, { scale: 1.2, xPercent: -50, duration: 2, ease, overwrite: "auto" }, 0);
+
+        if (label) {
+          tl.to(label, { y: -(h + 8), duration: 2, ease, overwrite: "auto" }, 0);
+        }
+
+        if (white) {
+          gsap.set(white, { y: Math.ceil(h + 100), opacity: 0 });
+          tl.to(white, { y: 0, opacity: 1, duration: 2, ease, overwrite: "auto" }, 0);
+        }
+
+        tlRefs.current[index] = tl;
+      });
+    };
+
+    layout();
+
+    const onResize = () => layout();
+    window.addEventListener("resize", onResize);
+
+    if (document.fonts?.ready) {
+      document.fonts.ready.then(layout).catch(() => {});
+    }
+
+    const menu = mobileMenuRef.current;
+    if (menu) {
+      gsap.set(menu, { visibility: "hidden", opacity: 0, scaleY: 1 });
+    }
+
+    if (initialLoadAnimation) {
+      const logo = logoRef.current;
+      const navItems = navItemsRef.current;
+
+      if (logo) {
+        gsap.set(logo, { scale: 0 });
+        gsap.to(logo, {
+          scale: 1,
+          duration: 0.6,
+          ease,
+        });
+      }
+
+      if (navItems) {
+        gsap.set(navItems, { width: 0, overflow: "hidden" });
+        gsap.to(navItems, {
+          width: "auto",
+          duration: 0.6,
+          ease,
+        });
+      }
+    }
+
+    return () => window.removeEventListener("resize", onResize);
+  }, [items, ease, initialLoadAnimation]);
+
+  const handleEnter = (i: number) => {
+    const tl = tlRefs.current[i];
+    if (!tl) return;
+    activeTweenRefs.current[i]?.kill();
+    activeTweenRefs.current[i] = tl.tweenTo(tl.duration(), {
+      duration: 0.3,
+      ease,
+      overwrite: "auto",
+    });
+  };
+
+  const handleLeave = (i: number) => {
+    const tl = tlRefs.current[i];
+    if (!tl) return;
+    activeTweenRefs.current[i]?.kill();
+    activeTweenRefs.current[i] = tl.tweenTo(0, {
+      duration: 0.2,
+      ease,
+      overwrite: "auto",
+    });
+  };
+
+  const handleLogoEnter = () => {
+    const img = logoImgRef.current;
+    if (!img) return;
+    logoTweenRef.current?.kill();
+    gsap.set(img, { rotate: 0 });
+    logoTweenRef.current = gsap.to(img, {
+      rotate: 360,
+      duration: 0.2,
+      ease,
+      overwrite: "auto",
+    });
+  };
+
+  const toggleMobileMenu = () => {
+    const newState = !isMobileMenuOpen;
+    setIsMobileMenuOpen(newState);
+
+    const hamburger = hamburgerRef.current;
+    const menu = mobileMenuRef.current;
+
+    if (hamburger) {
+      const lines = hamburger.querySelectorAll(".hamburger-line");
+      if (newState) {
+        gsap.to(lines[0], { rotation: 45, y: 3, duration: 0.3, ease });
+        gsap.to(lines[1], { rotation: -45, y: -3, duration: 0.3, ease });
+      } else {
+        gsap.to(lines[0], { rotation: 0, y: 0, duration: 0.3, ease });
+        gsap.to(lines[1], { rotation: 0, y: 0, duration: 0.3, ease });
+      }
+    }
+
+    if (menu) {
+      if (newState) {
+        gsap.set(menu, { visibility: "visible" });
+        gsap.fromTo(
+          menu,
+          { opacity: 0, y: 10, scaleY: 1 },
+          {
+            opacity: 1,
+            y: 0,
+            scaleY: 1,
+            duration: 0.3,
+            ease,
+            transformOrigin: "top center",
+          }
+        );
+      } else {
+        gsap.to(menu, {
+          opacity: 0,
+          y: 10,
+          scaleY: 1,
+          duration: 0.2,
+          ease,
+          transformOrigin: "top center",
+          onComplete: () => {
+            gsap.set(menu, { visibility: "hidden" });
+          },
+        });
+      }
+    }
+
+    onMobileMenuClick?.();
+  };
+
+  const isExternalLink = (href: string) =>
+    href.startsWith("http://") ||
+    href.startsWith("https://") ||
+    href.startsWith("//") ||
+    href.startsWith("mailto:") ||
+    href.startsWith("tel:") ||
+    href.startsWith("#");
+
+  const isRouterLink = (href?: string) => href && !isExternalLink(href);
+
+  const cssVars = {
+    ["--base"]: baseColor,
+    ["--pill-bg"]: pillColor,
+    ["--hover-text"]: hoveredPillTextColor,
+    ["--pill-text"]: resolvedPillTextColor,
+  } as React.CSSProperties;
+
+  return (
+    <div className="pill-nav-container">
+      <nav className={`pill-nav ${className}`} aria-label="Primary" style={cssVars}>
+        {isRouterLink(items?.[0]?.href) ? (
+          <Link
+            className="pill-logo"
+            to={items[0].href}
+            aria-label="Home"
+            onMouseEnter={handleLogoEnter}
+            role="menuitem"
+            ref={(el) => {
+              logoRef.current = el;
+            }}
+          >
+            <img src={logo} alt={logoAlt} ref={logoImgRef} />
+          </Link>
+        ) : (
+          <a
+            className="pill-logo"
+            href={items?.[0]?.href || "#"}
+            aria-label="Home"
+            onMouseEnter={handleLogoEnter}
+            ref={(el) => {
+              logoRef.current = el;
+            }}
+          >
+            <img src={logo} alt={logoAlt} ref={logoImgRef} />
+          </a>
+        )}
+
+        <div className="pill-nav-items desktop-only" ref={navItemsRef}>
+          <ul className="pill-list" role="menubar">
+            {items.map((item, i) => (
+              <li key={item.href} role="none">
+                {isRouterLink(item.href) ? (
+                  <Link
+                    role="menuitem"
+                    to={item.href}
+                    className={`pill${activeHref === item.href ? " is-active" : ""}`}
+                    aria-label={item.ariaLabel || item.label}
+                    onMouseEnter={() => handleEnter(i)}
+                    onMouseLeave={() => handleLeave(i)}
+                  >
+                    <span
+                      className="hover-circle"
+                      aria-hidden="true"
+                      ref={(el) => {
+                        circleRefs.current[i] = el;
+                      }}
+                    />
+                    <span className="label-stack">
+                      <span className="pill-label">{item.label}</span>
+                      <span className="pill-label-hover" aria-hidden="true">
+                        {item.label}
+                      </span>
+                    </span>
+                  </Link>
+                ) : (
+                  <a
+                    role="menuitem"
+                    href={item.href}
+                    className={`pill${activeHref === item.href ? " is-active" : ""}`}
+                    aria-label={item.ariaLabel || item.label}
+                    onMouseEnter={() => handleEnter(i)}
+                    onMouseLeave={() => handleLeave(i)}
+                  >
+                    <span
+                      className="hover-circle"
+                      aria-hidden="true"
+                      ref={(el) => {
+                        circleRefs.current[i] = el;
+                      }}
+                    />
+                    <span className="label-stack">
+                      <span className="pill-label">{item.label}</span>
+                      <span className="pill-label-hover" aria-hidden="true">
+                        {item.label}
+                      </span>
+                    </span>
+                  </a>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <button
+          className="mobile-menu-button mobile-only"
+          onClick={toggleMobileMenu}
+          aria-label="Toggle menu"
+          ref={hamburgerRef}
+        >
+          <span className="hamburger-line" />
+          <span className="hamburger-line" />
+        </button>
+      </nav>
+
+      <div className="mobile-menu-popover mobile-only" ref={mobileMenuRef} style={cssVars}>
+        <ul className="mobile-menu-list">
+          {items.map((item) => (
+            <li key={item.href}>
+              {isRouterLink(item.href) ? (
+                <Link
+                  to={item.href}
+                  className={`mobile-menu-link${activeHref === item.href ? " is-active" : ""}`}
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  {item.label}
+                </Link>
+              ) : (
+                <a
+                  href={item.href}
+                  className={`mobile-menu-link${activeHref === item.href ? " is-active" : ""}`}
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  {item.label}
+                </a>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default PillNav;

--- a/frontend/chu/src/index.css
+++ b/frontend/chu/src/index.css
@@ -9,7 +9,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   word-break: keep-all;
-  font-family: "DungGeonMo";
+  font-family: "Pretendard";
   background-color: #0d1116;
   color: #f0f6fc;
   min-height: 100vh;
@@ -21,8 +21,8 @@ body {
 }
 
 @font-face {
-  font-family: "DungGeonMo";
-  src: url("/src/assets/fonts/DungGeunMo.woff2") format("woff2");
+  font-family: "Pretendard";
+  src: url("/src/assets/fonts/PretendardVariable.woff2") format("woff2");
   font-weight: 100 900;
   font-display: swap;
   font-style: normal;

--- a/frontend/chu/src/main.tsx
+++ b/frontend/chu/src/main.tsx
@@ -4,45 +4,11 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
 import "./i18n";
-import FaultyTerminal from "./components/ReactBits/FaultyTerminal";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter>
-      <div style={{ position: "relative", width: "100%", height: "100vh" }}>
-        <FaultyTerminal
-          scale={2}
-          gridMul={[2, 1]}
-          digitSize={1.5}
-          timeScale={0.5}
-          pause={false}
-          scanlineIntensity={0}
-          glitchAmount={0}
-          flickerAmount={0}
-          noiseAmp={1}
-          chromaticAberration={0}
-          dither={0}
-          curvature={0}
-          tint="#ffffffff"
-          mouseReact={true}
-          mouseStrength={1}
-          pageLoadAnimation={true}
-          brightness={0.2}
-        />
-      </div>
-      <div
-        style={{
-          position: "absolute",
-          top: 0,
-          left: 0,
-          width: "100%",
-          height: "100%",
-          zIndex: 1,
-          pointerEvents: "none",
-        }}
-      >
-        <App />
-      </div>
+      <App />
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/chu/src/pages/Landing/Landing.module.css
+++ b/frontend/chu/src/pages/Landing/Landing.module.css
@@ -2,28 +2,24 @@
   max-width: 1024px;
   margin: 0 auto;
   display: flex;
-  justify-content: center;
+  align-items: center; /* 세로 중앙 정렬 */
   width: 100%;
-  gap: 100px;
-  background-color: rgba(10, 10, 10, 0.8);
-  border: 1px solid #444c56;
-  border-radius: 16px;
-  padding: 40px 100px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-  pointer-events: none;
+  gap: 50px;
 }
 
-/* 미디어쿼리 넣어서 반응형 디자인 적용 */
-/* landing 클래스를 display block으로 변경 */
-
-/* .heroContent {
+/* heroContent와 holoCardContainer가 1:1 비율로 너비를 나눠 갖도록 설정 */
+.heroContent,
+.holoCardContainer {
+  flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  max-width: 400px;
-  min-width: 350px;
-  pointer-events: auto;
-} */
+  justify-content: center;
+}
+
+/* HoloCard가 컨테이너 중앙에 오도록 설정 */
+.holoCardContainer {
+  align-items: center;
+}
 
 .title {
   font-size: 48px;
@@ -37,15 +33,5 @@
 .subtitle {
   font-size: 18px;
   line-height: 1.6;
-}
-
-.heroVisual {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  object-fit: cover;
-  width: 50%;
-  border: 1px solid #3d444d;
-  border-radius: 8px;
-  pointer-events: auto;
+  margin-top: 24px;
 }

--- a/frontend/chu/src/pages/Landing/Landing.tsx
+++ b/frontend/chu/src/pages/Landing/Landing.tsx
@@ -4,7 +4,7 @@ import Button from "../../components/common/Button";
 import styles from "./Landing.module.css";
 import { useTranslation } from "react-i18next";
 import heroVisual from "../../assets/images/heroImg.svg";
-import TiltedCard from "../../components/ReactBits/TiltedCard";
+import HoloCard from "../../components/ReactBits/HoloCard";
 
 const Landing = () => {
   const { user } = useUserStore();
@@ -30,20 +30,9 @@ const Landing = () => {
       </div>
 
       {/* 우측영역 */}
-      <TiltedCard
-        imageSrc={heroVisual}
-        altText="Comitchu Hero Image"
-        captionText="Comitchu"
-        containerHeight="300px"
-        containerWidth="300px"
-        imageHeight="300px"
-        imageWidth="300px"
-        rotateAmplitude={12}
-        scaleOnHover={1.2}
-        showMobileWarning={false}
-        showTooltip={true}
-        displayOverlayContent={true}
-      />
+      <div className={styles.holoCardContainer}>
+        <HoloCard imageSrc={heroVisual} />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
- FaultyTerminal 컴포넌트를 제거하고 관련 스타일을 정리합니다.
- Pretendard 폰트를 프로젝트의 기본 글꼴로 설정합니다.
- Landing 페이지 레이아웃을 heroContent와 HoloCard가 1:1 비율을 차지하도록 개편하고, 새로운 HoloCard 컴포넌트를 적용합니다.
- Header 레이아웃을 3분할 구조(중앙 내비게이션, 우측 사용자 정보)로 변경하고, 새로운 PillNav 컴포넌트를 적용합니다.
- 기타 UI 컴포넌트들의 스타일을 수정합니다.