### PR TITLE
feat: 츄 마크다운 클립보드 복사 기능 추가

### DIFF
--- a/frontend/chu/src/i18n/locales/en/translation.json
+++ b/frontend/chu/src/i18n/locales/en/translation.json
@@ -29,7 +29,8 @@
     "status": "Status",
     "language": "Language",
     "background": "Background",
-    "noChu": "No main chu selected."
+    "noChu": "No main chu selected.",
+    "copiedToClipboard": "Copied to clipboard"
   },
   "chuSkinSelector": {
     "fetchError": "Failed to load skin list.",

--- a/frontend/chu/src/i18n/locales/ko/translation.json
+++ b/frontend/chu/src/i18n/locales/ko/translation.json
@@ -28,7 +28,8 @@
     "status": "상태",
     "language": "언어",
     "background": "배경",
-    "noChu": "선택된 메인 츄가 없습니다."
+    "noChu": "선택된 메인 츄가 없습니다.",
+    "copiedToClipboard": "클립보드에 저장됨"
   },
   "chuSkinSelector": {
     "fetchError": "스킨 목록을 불러오는데 실패했습니다.",

--- a/frontend/chu/src/index.css
+++ b/frontend/chu/src/index.css
@@ -47,6 +47,22 @@ body {
   animation: slideUp 0.8s ease-out forwards;
 }
 
+/* ===== Animation: Slide Down ===== */
+@keyframes slideDown {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(40px);
+  }
+}
+
+.animate-slide-down {
+  animation: slideDown 0.8s ease-out forwards;
+}
+
 /* ===== CRT Effect ===== */
 :root {
   --crt-scanline-size: 2px;

--- a/frontend/chu/src/pages/Dashboard/Dashboard.module.css
+++ b/frontend/chu/src/pages/Dashboard/Dashboard.module.css
@@ -81,3 +81,29 @@
 .error {
   color: red;
 }
+
+.copyButton {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  background: #00000020;
+  border: 2px solid #eee;
+  border-radius: 8px;
+  cursor: pointer;
+  margin: 1rem;
+  padding: 6px;
+  display: inline-flex;
+  color: #eee;
+}
+
+.copyModal {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background-color: #333;
+  color: white;
+  padding: 10px 20px;
+  border-radius: 5px;
+  z-index: 1000;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+}

--- a/frontend/chu/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/chu/src/pages/Dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, Fragment, useRef } from "react";
 import useUserStore from "../../store/userStore";
 import useChuStore from "../../store/chuStore";
 import { fetchChuSvgAPI } from "../../api/chu";
@@ -8,6 +8,9 @@ import { useTranslation } from "react-i18next";
 const Dashboard = () => {
   const { t } = useTranslation();
   const { mainChu, isLoading, error, fetchMainChu } = useChuStore();
+  const [showCopyModal, setShowCopyModal] = useState(false);
+  const [isExiting, setIsExiting] = useState(false);
+  const modalTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // 로그인한 사용자 정보
   const user = useUserStore((state) => state.user);
@@ -39,6 +42,37 @@ const Dashboard = () => {
     getChuSvg();
   }, [user, t]);
 
+  useEffect(() => {
+    // Cleanup timeout on component unmount
+    return () => {
+      if (modalTimeoutRef.current) {
+        clearTimeout(modalTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopyClick = () => {
+    if (user && user.userName) {
+      if (modalTimeoutRef.current) {
+        clearTimeout(modalTimeoutRef.current);
+      }
+
+      const textToCopy = `<a href="https://www.comitchu.shop" target="_blank"><img src="https://www.comitchu.shop/api/chu/mini-${user.userName}" alt="커밋츄" width="300" height="200" /></a>`;
+      navigator.clipboard.writeText(textToCopy).then(() => {
+        setShowCopyModal(true);
+        setIsExiting(false);
+
+        modalTimeoutRef.current = setTimeout(() => {
+          setIsExiting(true);
+
+          modalTimeoutRef.current = setTimeout(() => {
+            setShowCopyModal(false);
+          }, 800); // Animation duration
+        }, 2200); // Time before exit starts
+      });
+    }
+  };
+
   if (isLoading || svgLoading) {
     return <p>{t("dashboard.loading")}</p>;
   }
@@ -48,38 +82,52 @@ const Dashboard = () => {
   }
 
   return (
-    <div className={`${styles.dashboard} animate-slide-up`}>
-      <div className={styles.contentWrapper}>
-        {svgContent && (
-          <div className={styles.svgImageContainer}>
-            <div className={styles.svgImageBackground} dangerouslySetInnerHTML={{ __html: svgContent }} />
-            <div className={styles.svgImage} dangerouslySetInnerHTML={{ __html: svgContent }} />
-          </div>
-        )}
-        <div className={styles.mainChuSection}>
-          {mainChu ? (
-            <div>
-              <h2>{mainChu.nickname}</h2>
-              <p>
-                {t("dashboard.level")}: {mainChu.level}
-              </p>
-              <p>
-                {t("dashboard.exp")}: {mainChu.exp}
-              </p>
-              <p>
-                {t("dashboard.status")}: {mainChu.status}
-              </p>
-              <p>
-                {t("dashboard.language")}: {mainChu.lang}
-              </p>
-              {/* <p>{t("dashboard.background")}: {mainChu.background}</p> */}
+    <Fragment>
+      <div className={`${styles.dashboard} animate-slide-up`}>
+        <div className={styles.contentWrapper}>
+          {svgContent && (
+            <div className={styles.svgImageContainer}>
+              <div className={styles.svgImageBackground} dangerouslySetInnerHTML={{ __html: svgContent }} />
+              <div className={styles.svgImage} dangerouslySetInnerHTML={{ __html: svgContent }} />
             </div>
-          ) : (
-            <p>{t("dashboard.noChu")}</p>
           )}
+          <div className={styles.mainChuSection}>
+            {mainChu ? (
+              <div>
+                <h2>{mainChu.nickname}</h2>
+                <p>
+                  {t("dashboard.level")}: {mainChu.level}
+                </p>
+                <p>
+                  {t("dashboard.exp")}: {mainChu.exp}
+                </p>
+                <p>
+                  {t("dashboard.status")}: {mainChu.status}
+                </p>
+                <p>
+                  {t("dashboard.language")}: {mainChu.lang}
+                </p>
+                <button onClick={handleCopyClick} className={styles.copyButton}>
+                  <svg viewBox="0 0 22 22" width="32px" height="32px">
+                    <path
+                      fill="currentColor"
+                      d="M4 2H18V3H19V4H20V18H19V19H18V20H4V19H3V18H2V4H3V3H4V2M17 5V4H5V5H4V17H5V18H17V17H18V5H17M6 8H16V10H6V8M6 12H13V14H6V12Z"
+                    ></path>
+                  </svg>
+                </button>
+              </div>
+            ) : (
+              <p>{t("dashboard.noChu")}</p>
+            )}
+          </div>
         </div>
       </div>
-    </div>
+      {showCopyModal && (
+        <div className={`${styles.copyModal} ${isExiting ? "animate-slide-down" : "animate-slide-up"}`}>
+          {t("dashboard.copiedToClipboard")}
+        </div>
+      )}
+    </Fragment>
   );
 };
 


### PR DESCRIPTION
대시보드 페이지에 자신의 츄 캐릭터 마크다운 스니펫을 클립보드에 복사하는 새로운 기능을 구현합니다.

- 메인 츄 정보 섹션에 복사 아이콘 버튼을 추가합니다.
- 버튼 클릭 시 사용자의 미니 츄 이미지 URL이 포함된 마크다운 링크가 복사됩니다.
- 복사 성공 시 화면 우측 하단에 확인 모달이 나타납니다.
- 모달은 등장 및 퇴장 시 슬라이드 업/다운 애니메이션 효과를 가집니다.
- 확인 모달 텍스트를 위해 한국어 및 영어 i18n 번역을 추가합니다.